### PR TITLE
refactor: rename RAG configuration class

### DIFF
--- a/examples/langgraph-sls-fastapi-rag/app/rag_graph/configuration.py
+++ b/examples/langgraph-sls-fastapi-rag/app/rag_graph/configuration.py
@@ -10,9 +10,8 @@ from langchain_core.runnables import RunnableConfig, ensure_config
 from . import prompts
 
 
-#TODO: rename to RAGConfiguration
 @dataclass(kw_only=True)
-class IndexConfiguration:
+class RAGConfiguration:
     """Configuration class for indexing and retrieval operations.
 
     This class defines the parameters needed for configuring the indexing and
@@ -54,14 +53,14 @@ class IndexConfiguration:
     def from_runnable_config(
         cls: Type[T], config: Optional[RunnableConfig] = None
     ) -> T:
-        """Create an IndexConfiguration instance from a RunnableConfig object.
+        """Create a RAGConfiguration instance from a RunnableConfig object.
 
         Args:
             cls (Type[T]): The class itself.
             config (Optional[RunnableConfig]): The configuration object to use.
 
         Returns:
-            T: An instance of IndexConfiguration with the specified configuration.
+            T: An instance of RAGConfiguration with the specified configuration.
         """
         config = ensure_config(config)
         configurable = config.get("configurable") or {}
@@ -69,11 +68,11 @@ class IndexConfiguration:
         return cls(**{k: v for k, v in configurable.items() if k in _fields})
 
 
-T = TypeVar("T", bound=IndexConfiguration)
+T = TypeVar("T", bound=RAGConfiguration)
 
 
 @dataclass(kw_only=True)
-class Configuration(IndexConfiguration):
+class Configuration(RAGConfiguration):
     """The configuration for the agent."""
 
     response_system_prompt: str = field(

--- a/examples/langgraph-sls-fastapi-rag/app/rag_graph/retrieval.py
+++ b/examples/langgraph-sls-fastapi-rag/app/rag_graph/retrieval.py
@@ -15,7 +15,7 @@ from langchain_core.embeddings import Embeddings
 from langchain_core.runnables import RunnableConfig
 from langchain_core.vectorstores import VectorStoreRetriever
 
-from .configuration import Configuration, IndexConfiguration
+from .configuration import Configuration, RAGConfiguration
 
 ## Encoder constructors
 logger = logging.getLogger(__name__)
@@ -44,7 +44,7 @@ def make_text_encoder(model: str) -> Embeddings:
 
 @contextmanager
 def make_elastic_retriever(
-    configuration: IndexConfiguration, embedding_model: Embeddings
+    configuration: RAGConfiguration, embedding_model: Embeddings
 ) -> Generator[VectorStoreRetriever, None, None]:
     """Configure this agent to connect to a specific elastic index."""
     from langchain_elasticsearch import ElasticsearchStore
@@ -75,7 +75,7 @@ def make_elastic_retriever(
 
 @contextmanager
 def make_pinecone_retriever(
-    configuration: IndexConfiguration, embedding_model: Embeddings
+    configuration: RAGConfiguration, embedding_model: Embeddings
 ) -> Generator[VectorStoreRetriever, None, None]:
     """Configure this agent to connect to a specific pinecone index."""
     from langchain_pinecone import PineconeVectorStore
@@ -92,7 +92,7 @@ def make_pinecone_retriever(
 
 @contextmanager
 def make_mongodb_retriever(
-    configuration: IndexConfiguration, embedding_model: Embeddings
+    configuration: RAGConfiguration, embedding_model: Embeddings
 ) -> Generator[VectorStoreRetriever, None, None]:
     """Configure this agent to connect to a specific MongoDB Atlas index & namespaces."""
     from langchain_mongodb.vectorstores import MongoDBAtlasVectorSearch
@@ -113,7 +113,7 @@ def make_retriever(
     config: RunnableConfig,
 ) -> Generator[VectorStoreRetriever, None, None]:
     """Create a retriever for the agent, based on the current configuration."""
-    configuration = IndexConfiguration.from_runnable_config(config)
+    configuration = RAGConfiguration.from_runnable_config(config)
     embedding_model = make_text_encoder(configuration.embedding_model)
     user_id = configuration.user_id
     if not user_id:


### PR DESCRIPTION
## Description

Renames the LangGraph RAG example's `IndexConfiguration` class to `RAGConfiguration` and updates all local imports, type hints, inheritance, and docstrings.

Fixes #117

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] `python -m compileall -q app/rag_graph`
- [x] `uvx ruff check app/rag_graph/configuration.py app/rag_graph/retrieval.py`

`ruff format --check` reports that both pre-existing files would be reformatted; this PR avoids unrelated whole-file formatting.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated retrieval configuration terminology to focus on retrieval-augmented generation (RAG) behavior.
  - Preserved existing configurable settings and retriever behavior across Elasticsearch, Pinecone, and MongoDB.
  - Maintained filtering of supported runtime configuration values for consistent setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->