### PR TITLE
fix(lint): apply black formatting and style fixes in RAG example

### DIFF
--- a/examples/langgraph-sls-fastapi-rag/app/rag_graph/configuration.py
+++ b/examples/langgraph-sls-fastapi-rag/app/rag_graph/configuration.py
@@ -21,7 +21,7 @@ class RAGConfiguration:
 
     user_id: str = field(metadata={"description": "Unique identifier for the user."})
 
-    # add 
+    # add
     embedding_model: Annotated[
         str,
         {"__template_metadata__": {"kind": "embeddings"}},
@@ -81,7 +81,7 @@ class Configuration(RAGConfiguration):
     )
 
     response_model: Annotated[str, {"__template_metadata__": {"kind": "llm"}}] = field(
-        #default="anthropic/claude-3-5-sonnet-20240620",
+        # default="anthropic/claude-3-5-sonnet-20240620",
         default="openai/gpt-4o-mini",
         metadata={
             "description": "The language model used for generating responses. Should be in the form: provider/model-name."
@@ -96,7 +96,7 @@ class Configuration(RAGConfiguration):
     )
 
     query_model: Annotated[str, {"__template_metadata__": {"kind": "llm"}}] = field(
-        #default="anthropic/claude-3-haiku-20240307",
+        # default="anthropic/claude-3-haiku-20240307",
         default="openai/gpt-4o-mini",
         metadata={
             "description": "The language model used for processing and refining queries. Should be in the form: provider/model-name."

--- a/examples/langgraph-sls-fastapi-rag/app/rag_graph/retrieval.py
+++ b/examples/langgraph-sls-fastapi-rag/app/rag_graph/retrieval.py
@@ -20,11 +20,13 @@ from .configuration import Configuration, RAGConfiguration
 ## Encoder constructors
 logger = logging.getLogger(__name__)
 
+
 def make_text_encoder(model: str) -> Embeddings:
     """Connect to the configured text encoder."""
     if "/" not in model:
-        raise ValueError(f"Invalid model format: {model}. Expected format: 'provider/model'")
-        
+        raise ValueError(
+            f"Invalid model format: {model}. Expected format: 'provider/model'"
+        )
     provider, model = model.split("/", maxsplit=1)
     match provider:
         case "openai":
@@ -81,14 +83,15 @@ def make_pinecone_retriever(
     from langchain_pinecone import PineconeVectorStore
 
     user_search_kwargs = configuration.search_kwargs or {}
-    user_search_kwargs['filter'] = {
-        **user_search_kwargs.get('filter', {}),
-        "user_id": {"$eq": configuration.user_id}
+    user_search_kwargs["filter"] = {
+        **user_search_kwargs.get("filter", {}),
+        "user_id": {"$eq": configuration.user_id},
     }
     vstore = PineconeVectorStore.from_existing_index(
         os.environ["PINECONE_INDEX_NAME"], embedding=embedding_model
     )
     yield vstore.as_retriever(search_kwargs=user_search_kwargs)
+
 
 @contextmanager
 def make_mongodb_retriever(


### PR DESCRIPTION
## Summary

Follow-up lint fixes after merging #139 (refactor: rename RAG configuration class).

- Wrap long `raise ValueError` line in `retrieval.py` to satisfy black line-length limit
- Add missing blank line before module-level function `make_text_encoder` (E302)
- Replace single quotes with double quotes in pinecone retriever dict (black style)
- Remove trailing whitespace from `# add` inline comment in `configuration.py` (W291)
- Add space after `#` in commented-out default values (E265)

These are minor style issues that the contributor deliberately left out to avoid unrelated whole-file reformatting. Applying them here to get CI fully green.

## Test plan

- [ ] CI: Lint Code Base passes ✅
- [ ] No behavior changes — formatting only