### PR TITLE
fix(lint): fix flake8 E501 and E266 violations in RAG example

### DIFF
--- a/examples/langgraph-sls-fastapi-rag/app/rag_graph/configuration.py
+++ b/examples/langgraph-sls-fastapi-rag/app/rag_graph/configuration.py
@@ -38,7 +38,10 @@ class RAGConfiguration:
     ] = field(
         default="pinecone",
         metadata={
-            "description": "The vector store provider to use for retrieval. Options are 'elastic', 'pinecone', or 'mongodb'."
+            "description": (
+                "The vector store provider to use for retrieval. "
+                "Options are 'elastic', 'pinecone', or 'mongodb'."
+            )
         },
     )
 
@@ -84,7 +87,10 @@ class Configuration(RAGConfiguration):
         # default="anthropic/claude-3-5-sonnet-20240620",
         default="openai/gpt-4o-mini",
         metadata={
-            "description": "The language model used for generating responses. Should be in the form: provider/model-name."
+            "description": (
+                "The language model used for generating responses. "
+                "Should be in the form: provider/model-name."
+            )
         },
     )
 
@@ -99,6 +105,9 @@ class Configuration(RAGConfiguration):
         # default="anthropic/claude-3-haiku-20240307",
         default="openai/gpt-4o-mini",
         metadata={
-            "description": "The language model used for processing and refining queries. Should be in the form: provider/model-name."
+            "description": (
+                "The language model used for processing and refining queries. "
+                "Should be in the form: provider/model-name."
+            )
         },
     )

--- a/examples/langgraph-sls-fastapi-rag/app/rag_graph/retrieval.py
+++ b/examples/langgraph-sls-fastapi-rag/app/rag_graph/retrieval.py
@@ -17,7 +17,7 @@ from langchain_core.vectorstores import VectorStoreRetriever
 
 from .configuration import Configuration, RAGConfiguration
 
-## Encoder constructors
+# Encoder constructors
 logger = logging.getLogger(__name__)
 
 
@@ -41,7 +41,7 @@ def make_text_encoder(model: str) -> Embeddings:
             raise ValueError(f"Unsupported embedding provider: {provider}")
 
 
-## Retriever constructors
+# Retriever constructors
 
 
 @contextmanager


### PR DESCRIPTION
## Summary

Final lint fixes for the RAG example, following #139 and #141.

- **E501**: Wrap long metadata `description` strings (retriever_provider, response_model, query_model fields) to stay under 120 chars
- **E266**: Change `##` section headers to `#` (flake8 requires single `#` for block comments)

These are pre-existing issues in files touched by #139 — the contributor deliberately avoided whole-file reformatting, so they're being addressed in follow-up commits.

## Test plan

- [ ] CI: `Lint Code Base` passes ✅ — specifically PYTHON_FLAKE8
- [ ] No behavior changes — formatting and style only